### PR TITLE
EX Raid Support

### DIFF
--- a/src/raid_coordinator/bot.py
+++ b/src/raid_coordinator/bot.py
@@ -555,7 +555,8 @@ async def cleanup_raid_channels():
                             await end_raid_group(channel)
 
                 # refresh the active raids if it has been too long
-                if datetime.utcnow() - last_active_raid_refresh_time > max_active_raids_channel_age:
+                raids_in_progress = any(not is_open(channel) for channel in channels)
+                if raids_in_progress and datetime.utcnow() - last_active_raid_refresh_time > max_active_raids_channel_age:
                     should_refresh_active_raids = True
 
                 # list the active raids every cycle

--- a/src/raid_coordinator/bot.py
+++ b/src/raid_coordinator/bot.py
@@ -419,9 +419,14 @@ async def end_raid_group(channel):
 
 async def invite_user_to_raid(channel, user):
     """Invites a user to the raid channel."""
+    global should_refresh_active_raids
+
     # don't invite bots and webhooks
     if user.bot:
         return
+
+    # refresh active raids in future
+    should_refresh_active_raids = True
 
     # adds an overwrite for the user
     perms = discord.PermissionOverwrite(read_messages=True)
@@ -440,9 +445,14 @@ async def invite_user_to_raid(channel, user):
 
 async def uninvite_user_from_raid(channel, user):
     """Removes a user from a raid channel."""
+    global should_refresh_active_raids
+
     # skip bots and webhooks
     if user.bot:
         return
+
+    # refresh active raids in future
+    should_refresh_active_raids = True
 
     # reflect the proper number of members (the bot role and everyone are excluded)
     await client.delete_channel_permissions(channel, user)


### PR DESCRIPTION
# What

* Adds better EX raid support, letting the bot handle long lived messages on active servers more gracefully

# ToDo

* Docs for setting up for EX raids